### PR TITLE
Fix experiment runner resume

### DIFF
--- a/Script.py
+++ b/Script.py
@@ -219,7 +219,7 @@ def read_args():
     parser.add_argument("--project", required=True, type=str)
     parser.add_argument("--project-folder", type=str, default="projects")
     parser.add_argument("--prompt-strategy", type=str, choices=['ChoiEtAl', 'Ours'], default='ChoiEtAl')
-    parser.add_argument("--model", type=str, choices=['gpt-4o-mini', 'gpt-4.1-mini', 'gemini-2.5-flash', 'gpt-5-mini', 'gpt-5-nano', 'deepseek-r1:1.5b'], default='gpt-4o-mini')
+    parser.add_argument("--model", type=str, choices=['gpt-4o-mini', 'gpt-4.1-mini', 'gemini-2.5-flash', 'gpt-5-mini', 'gpt-5-nano', 'gpt-oss:120b', 'deepseek-r1:1.5b'], default='gpt-4o-mini')
     parser.add_argument("--reasoning-effort", type=str)
     parser.add_argument("--base-log-dir", type=str, default="logs/")
     parser.add_argument("--iterations", type=int, default=20)

--- a/experiment_runner.py
+++ b/experiment_runner.py
@@ -276,7 +276,7 @@ class ExistingRunScanner:
                 )
                 grouped.setdefault(base_key, []).append(
                     RunRecord(
-                        combination=RunCombination(base_key[0], base_key[1], base_key[2], 0),
+                        combination=RunCombination(base_key[0], base_key[1], base_key[2], run_index=0),
                         run_dir=run_dir,
                         csv_file=csv_file,
                     )
@@ -286,7 +286,7 @@ class ExistingRunScanner:
         indexed: Dict[Tuple[str, str, str, int], RunRecord] = {}
         for base_key, records in grouped.items():
             for idx, record in enumerate(sorted(records, key=lambda item: str(item.run_dir)), start=1):
-                combination = RunCombination(base_key[0], base_key[1], base_key[2], idx)
+                combination = RunCombination(base_key[0], base_key[1], base_key[2], run_index=idx)
                 indexed[combination.key()] = RunRecord(combination, record.run_dir, record.csv_file)
         return indexed
 


### PR DESCRIPTION
Fixes a bug in `ExistingRunScanner` where `run_index` was being assigned to the wrong dataclass field (`reasoning_effort`), causing every existing run to collapse to `run_index=1`. As a result, would re-execute runs 2..N for every (project, strategy, model) group instead of skipping them.

Also includes the gpt-oss:120b argparser entry